### PR TITLE
Replace missing, deprecated sgx_tstdcxx library with sgx_tcxx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ Enclave_C_Flags := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fst
 Enclave_Cpp_Flags := $(Enclave_C_Flags) -std=c++03 -nostdinc++
 Enclave_Link_Flags := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_LIBRARY_PATH) \
 	-Wl,--whole-archive -l$(Trts_Library_Name) -Wl,--no-whole-archive \
-	-Wl,--start-group -lsgx_tstdc -lsgx_tstdcxx -l$(Crypto_Library_Name) -l$(Service_Library_Name) -Wl,--end-group \
+	-Wl,--start-group -lsgx_tstdc -lsgx_tcxx -l$(Crypto_Library_Name) -l$(Service_Library_Name) -Wl,--end-group \
 	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
 	-Wl,-pie,-eenclave_entry -Wl,--export-dynamic  \
 	-Wl,--defsym,__ImageBase=0


### PR DESCRIPTION
Latest SGX SDK doesn't have this library, gives the following error - 
```
/usr/bin/ld: cannot find -lsgx_tstdcxx
collect2: error: ld returned 1 exit status
Makefile:203: recipe for target 'enclave.so' failed
make: *** [enclave.so] Error 1
```
See https://stackoverflow.com/questions/58265702/intel-sgx-training-lab-cannot-compile-examples-sgx-tstdcxx-lib-missing which gave the correct library

Just opened the PR since will be helpful if anyone tries to use and faces the error :)